### PR TITLE
display keyboard shortcuts in suggestions

### DIFF
--- a/command-bar.js
+++ b/command-bar.js
@@ -85,10 +85,15 @@ class CommandBar {
         desc_el.className = "text-shortcut";
         desc_el.appendChild(document.createTextNode(item.description));
 
+        var shortcut_el = document.createElement("div");
+        desc_el.className = "text-shortcut";
+        desc_el.appendChild(document.createTextNode(item.shortcut || ""));
+
         var list_item_el = document.createElement("div");
         list_item_el.className = "panel-list-item";
         list_item_el.appendChild(text_el);
         list_item_el.appendChild(desc_el);
+        list_item_el.appendChild(shortcut_el);
         list_item_el.onclick = async ev => {
             this.selectItem(index);
             this.input_el.focus();

--- a/commands.js
+++ b/commands.js
@@ -25,6 +25,7 @@ commands = [
     {
         name: "open new tab",
         desc: "",
+        shortcut: "Ctrl + T",
         run: (url) => {
             if (url !== undefined) {
                 browser.tabs.create({url: url});
@@ -37,6 +38,7 @@ commands = [
     {
         name: "reload this tab",
         desc: "",
+        shortcut: "F5, Ctrl+R",
         run: () => {browser.tabs.reload()},
         args: () => []
     },
@@ -69,12 +71,14 @@ commands = [
     {
         name: "mute this tab",
         desc: "",
+        shortcut: "Ctrl+M",
         run: () => {browser.tabs.update({muted: true})},
         args: () => []
     },
     {
         name: "unmute this tab",
         desc: "",
+        shortcut: "Ctrl+M",
         run: () => {browser.tabs.update({muted: false})},
         args: () => []
     },
@@ -93,6 +97,7 @@ commands = [
     {
         name: "close this tab",
         desc: "",
+        shortcut: "Ctrl+W, Ctrl+F4",
         run: async () => {
             const tabs = await browser.tabs.query({active: true, currentWindow: true});
             tabs.map(tab => {
@@ -104,18 +109,21 @@ commands = [
     {
         name: "open new window",
         desc: "",
+        shortcut: "Ctrl+N",
         run: () => {browser.windows.create({})},
         args: () => []
     },
     {
         name: "open new private window",
         desc: "",
+        shortcut: "Ctrl+Shift+P",
         run: () => {browser.windows.create({incognito: true})},
         args: () => []
     },
     {
         name: "close this window",
         desc: "",
+        shortcut: "Ctrl+Shift+W, Alt+F4",
         run: async () => {
             const current_window = await browser.windows.getCurrent();
             browser.windows.remove(current_window.id);

--- a/search.js
+++ b/search.js
@@ -32,11 +32,13 @@ async function onChange(input) {
         suggestions = [{
             name: command.name,
             desc: command.desc
+            // shortcuts for commands with args not supported for now
         }];
         const allowed_args = await command.args()
         suggestions = allowed_args.map((s) => Object({
             name: command.name + " " + s.content,
             desc: s.description
+            // shortcuts for commands with args not supported for now
         }));
 
         input = args;
@@ -46,7 +48,8 @@ async function onChange(input) {
 
     suggestions = suggestions.map(cmd => Object({
         name: cmd.name.toLowerCase(),
-        desc: cmd.desc.toLowerCase()
+        desc: cmd.desc.toLowerCase(),
+        shortcut: cmd.shortcut && cmd.shortcut.toLowerCase()
     }));
 
     // whatever set of suggestions we've ended up with, narrow
@@ -60,7 +63,8 @@ async function onChange(input) {
         .sort((a, b) => b.score - a.score)
         .map(cmd => Object({
             content: cmd.name,
-            description: cmd.desc
+            description: cmd.desc,
+            shortcut: cmd.shortcut
         }));
 
     return filtered_suggestions;


### PR DESCRIPTION
@dj311 would you be open to a feature like this? The current implementation is not completed yet, as only a subset of shortcuts has been added to commands.json. But I'd complete that if you consider the overall approach appropriate.

Background:
In my experience, this is a very effective way to learn keyboard shortcuts without a steep learning curve.

Limitations: shortcuts must be manually maintained in commands.json, but this probably works reasonably well as shortcuts probably don't change that often?

TODO: add more shortcuts from
https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly to commands.js